### PR TITLE
Store and restore the router from json

### DIFF
--- a/goodrouter-ts/.vscode/launch.json
+++ b/goodrouter-ts/.vscode/launch.json
@@ -7,10 +7,11 @@
       "name": "run file",
       "program": "${file}",
       "args": [],
-      "cwd": "${workspaceRoot}",
+      "cwd": "${workspaceFolder}",
       "sourceMaps": true,
-      "outFiles": ["${workspaceRoot}/out/**/*.js"],
-      "preLaunchTask": "watch"
+      "outFiles": ["${workspaceFolder}/out/**/*.js"],
+      "preLaunchTask": "watch",
+      "outputCapture": "std"
     }
   ]
 }

--- a/goodrouter-ts/.vscode/tasks.json
+++ b/goodrouter-ts/.vscode/tasks.json
@@ -2,10 +2,10 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "type": "typescript",
+      "type": "npm",
       "label": "watch",
-      "tsconfig": "tsconfig.json",
-      "option": "watch",
+      "script": "watch",
+      "isBackground": true,
       "problemMatcher": ["$tsc-watch"],
       "group": {
         "kind": "build",

--- a/goodrouter-ts/package.json
+++ b/goodrouter-ts/package.json
@@ -11,6 +11,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "watch": "tsc --watch",
     "clean": "rm -rf out",
     "test": "npm run spec-all",
     "lint": "prettier --check *",

--- a/goodrouter-ts/src/main.ts
+++ b/goodrouter-ts/src/main.ts
@@ -1,2 +1,3 @@
+export * from "./route-node-json.js";
 export * from "./router-options.js";
 export * from "./router.js";

--- a/goodrouter-ts/src/route-node-json.ts
+++ b/goodrouter-ts/src/route-node-json.ts
@@ -1,0 +1,6 @@
+export interface RouteNodeJson<K extends string | number> {
+    anchor: string;
+    hasParameter: boolean;
+    routeKey: K | null;
+    children: RouteNodeJson<K>[];
+}

--- a/goodrouter-ts/src/route-node.spec.ts
+++ b/goodrouter-ts/src/route-node.spec.ts
@@ -1,6 +1,7 @@
 import { permutations } from "itertools";
 import assert from "node:assert/strict";
 import test from "node:test";
+import { RouteNodeJson } from "./route-node-json.js";
 import { RouteNode } from "./route-node.js";
 import { defaultRouterOptions } from "./router-options.js";
 import { parseTemplatePairs } from "./template.js";
@@ -59,4 +60,48 @@ test("route-node-sort", () => {
     const nodesActual = [...nodes].sort((a, b) => a.compare(b));
 
     assert.deepEqual(nodesActual, nodesExpected);
+});
+
+test("route-node-json", () => {
+    const node = new RouteNode();
+    node.insert(1, [
+        ...parseTemplatePairs(
+            "x/y",
+            defaultRouterOptions.parameterPlaceholderRE,
+        ),
+    ]);
+    node.insert(2, [
+        ...parseTemplatePairs(
+            "x/z",
+            defaultRouterOptions.parameterPlaceholderRE,
+        ),
+    ]);
+    const actual = node.toJSON();
+    const expected: RouteNodeJson<number> = {
+        anchor: "",
+        hasParameter: false,
+        routeKey: null,
+        children: [
+            {
+                anchor: "x/",
+                hasParameter: false,
+                routeKey: null,
+                children: [
+                    {
+                        anchor: "y",
+                        hasParameter: false,
+                        routeKey: 1,
+                        children: [],
+                    },
+                    {
+                        anchor: "z",
+                        hasParameter: false,
+                        routeKey: 2,
+                        children: [],
+                    },
+                ],
+            },
+        ],
+    };
+    assert.deepEqual(actual, expected);
 });

--- a/goodrouter-ts/src/route-node.ts
+++ b/goodrouter-ts/src/route-node.ts
@@ -1,3 +1,4 @@
+import { RouteNodeJson } from "./route-node-json.js";
 import { findCommonPrefixLength } from "./utils/string.js";
 
 /**
@@ -22,13 +23,12 @@ export class RouteNode<K extends string | number> {
          * key that identifies the route, if this is a leaf node for the route
          */
         public routeKey: K | null = null,
+        /**
+         * @description
+         * children that represent the rest of the path that needs to be matched
+         */
+        private readonly children = new Array<RouteNode<K>>(),
     ) {}
-
-    /**
-     * @description
-     * children that represent the rest of the path that needs to be matched
-     */
-    private readonly children = new Array<RouteNode<K>>();
 
     private addChild(childNode: RouteNode<K>) {
         this.children.push(childNode);
@@ -322,5 +322,27 @@ export class RouteNode<K extends string | number> {
         if (this.anchor > other.anchor) return 1;
 
         return 0;
+    }
+
+    public toJSON(): RouteNodeJson<K> {
+        const json = {
+            anchor: this.anchor,
+            hasParameter: this.hasParameter,
+            routeKey: this.routeKey,
+            children: this.children.map((child) => child.toJSON()),
+        };
+        return json;
+    }
+
+    public static fromJSON<K extends string | number>(
+        json: RouteNodeJson<K>,
+    ): RouteNode<K> {
+        const node = new RouteNode(
+            json.anchor,
+            json.hasParameter,
+            json.routeKey,
+            json.children.map((child) => RouteNode.fromJSON(child)),
+        );
+        return node;
     }
 }

--- a/goodrouter-ts/src/router.ts
+++ b/goodrouter-ts/src/router.ts
@@ -1,3 +1,4 @@
+import { RouteNodeJson } from "./route-node-json.js";
 import { RouteNode } from "./route-node.js";
 import { defaultRouterOptions, RouterOptions } from "./router-options.js";
 import { parseTemplatePairs } from "./template.js";
@@ -153,5 +154,16 @@ export class Router<K extends string | number> {
             result += parameterAnchor;
         }
         return result;
+    }
+
+    public saveToJSON(): RouteNodeJson<K> {
+        const json = this.rootNode.toJSON();
+        return json;
+    }
+
+    public loadFromJSON(json: RouteNodeJson<K>) {
+        const node = RouteNode.fromJSON(json);
+        this.rootNode = node;
+        return this;
     }
 }

--- a/goodrouter-ts/tsconfig.json
+++ b/goodrouter-ts/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "@tsconfig/node20",
   "compilerOptions": {
     "outDir": "./out",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "sourceMap": true,
+    "declaration": true
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
The routes in the router usually never change during runtime. We could construct the router during compile time in some cases. This feature allows us to save and restore the configuration of the router so we can initialize the router faster and more convenient!

Also the typescript configuration was fixed, it was not generating types and sourcemaps, that had quite a few consequences!